### PR TITLE
Update HTTPTask.swift

### DIFF
--- a/HTTPTask.swift
+++ b/HTTPTask.swift
@@ -116,7 +116,7 @@ class HTTPTask : NSObject, NSURLSessionDelegate {
         //probably should change the 'http' to something more generic
         if !url.hasPrefix("http") && self.baseURL {
             var split = url.hasPrefix("/") ? "" : "/"
-            urlVal = "\(self.baseURL)\(split)\(url)"
+            urlVal = "\(self.baseURL!)\(split)\(url)"
         }
         if !self.requestSerializer {
             self.requestSerializer = HTTPRequestSerializer()


### PR DESCRIPTION
Unwrapped baseURL. This was working before. Maybe they changed string interpolation for optionals in beta4? This is the result I was getting without unwrapping...Optional("somesite.com/v1")/trending
