### PR TITLE
Fix a bug while sending array parameters

### DIFF
--- a/HTTPRequestSerializer.swift
+++ b/HTTPRequestSerializer.swift
@@ -104,11 +104,11 @@ class HTTPRequestSerializer: NSObject {
         var collect = Array<HTTPPair>()
         if let array = object as? Array<AnyObject> {
             for nestedValue : AnyObject in array {
-                collect.extend(self.serializeObject(nestedValue,key: "\(key)[]"))
+                collect.extend(self.serializeObject(nestedValue,key: "\(key!)[]"))
             }
         } else if let dict = object as? Dictionary<String,AnyObject> {
             for (nestedKey, nestedObject: AnyObject) in dict {
-                var newKey = key ? "\(key)[\(nestedKey)]" : nestedKey
+                var newKey = key ? "\(key!)[\(nestedKey)]" : nestedKey
                 collect.extend(self.serializeObject(nestedObject,key: newKey))
             }
         } else {


### PR DESCRIPTION
When sending array parameters, such as 'array':[1,2,3], the old function will get a key like 'Optional("array")', which actually should be 'array'.
