### PR TITLE
Fixed bug causing multipart PUT request to be replaced with POST

### DIFF
--- a/HTTPRequestSerializer.swift
+++ b/HTTPRequestSerializer.swift
@@ -88,7 +88,7 @@ public class HTTPRequestSerializer: NSObject {
             isMulti = isMultiForm(params)
         }
         if isMulti {
-            if(method != .POST || method != .PUT) {
+            if(method != .POST && method != .PUT) {
                 request.HTTPMethod = HTTPMethod.POST.rawValue // you probably wanted a post
             }
             var boundary = "Boundary+\(arc4random())\(arc4random())"


### PR DESCRIPTION
Due to a small logic error in HTTPRequestSerializer.createRequest(), multi-part form requests were being replaced with .POST when calling the PUT function.
