### PR TITLE
Add Carthage support

### DIFF
--- a/SwiftHTTP.xcodeproj/xcshareddata/xcschemes/SwiftHTTP.xcscheme
+++ b/SwiftHTTP.xcodeproj/xcshareddata/xcschemes/SwiftHTTP.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0610"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6BFD901519C8D8B500DD99B6"
+               BuildableName = "SwiftHTTP.framework"
+               BlueprintName = "SwiftHTTP"
+               ReferencedContainer = "container:SwiftHTTP.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6BFD901519C8D8B500DD99B6"
+            BuildableName = "SwiftHTTP.framework"
+            BlueprintName = "SwiftHTTP"
+            ReferencedContainer = "container:SwiftHTTP.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6BFD901519C8D8B500DD99B6"
+            BuildableName = "SwiftHTTP.framework"
+            BlueprintName = "SwiftHTTP"
+            ReferencedContainer = "container:SwiftHTTP.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SwiftHTTP.xcodeproj/xcshareddata/xcschemes/SwiftHTTPOSX.xcscheme
+++ b/SwiftHTTP.xcodeproj/xcshareddata/xcschemes/SwiftHTTPOSX.xcscheme
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0610"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D958025819E6EEEB003C8218"
+               BuildableName = "SwiftHTTPOSX.framework"
+               BlueprintName = "SwiftHTTPOSX"
+               ReferencedContainer = "container:SwiftHTTP.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D958026219E6EEEB003C8218"
+               BuildableName = "SwiftHTTPOSXTests.xctest"
+               BlueprintName = "SwiftHTTPOSXTests"
+               ReferencedContainer = "container:SwiftHTTP.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D958026219E6EEEB003C8218"
+               BuildableName = "SwiftHTTPOSXTests.xctest"
+               BlueprintName = "SwiftHTTPOSXTests"
+               ReferencedContainer = "container:SwiftHTTP.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D958025819E6EEEB003C8218"
+            BuildableName = "SwiftHTTPOSX.framework"
+            BlueprintName = "SwiftHTTPOSX"
+            ReferencedContainer = "container:SwiftHTTP.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D958025819E6EEEB003C8218"
+            BuildableName = "SwiftHTTPOSX.framework"
+            BlueprintName = "SwiftHTTPOSX"
+            ReferencedContainer = "container:SwiftHTTP.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D958025819E6EEEB003C8218"
+            BuildableName = "SwiftHTTPOSX.framework"
+            BlueprintName = "SwiftHTTPOSX"
+            ReferencedContainer = "container:SwiftHTTP.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tests/SwiftHTTPTests.swift
+++ b/Tests/SwiftHTTPTests.swift
@@ -31,7 +31,7 @@ class SwiftHTTPTests: XCTestCase {
             if response.responseObject != nil {
                 XCTAssert(true, "Pass")
             }
-            },failure: {(error: NSError) -> Void in
+            },failure: {(error: NSError, _) -> Void in
                 XCTAssert(false, "Failure")
         })
     }
@@ -51,7 +51,7 @@ class SwiftHTTPTests: XCTestCase {
             if response.responseObject != nil {
                 XCTAssert(true, "Pass")
             }
-            },failure: {(error: NSError) -> Void in
+            },failure: {(error: NSError, _) -> Void in
                 XCTAssert(false, "Failure")
         })
     }


### PR DESCRIPTION
In order for Carthage to work the schemes for the frameworks have to be shared. This does that. This also fixes a type error in the OS X framework tests.