### PR TITLE
Expose HTTPAdditionalHeaders through public param

### DIFF
--- a/HTTPTask.swift
+++ b/HTTPTask.swift
@@ -147,6 +147,8 @@ public class HTTPTask : NSObject, NSURLSessionDelegate, NSURLSessionTaskDelegate
     //Returning nil from this method will cause the request to be rejected and cancelled
     public var auth:((NSURLAuthenticationChallenge) -> NSURLCredential?)?
     
+    public var headers = [String:AnyObject]()
+    
     //MARK: Public Methods
     
     /// A newly minted HTTPTask for your enjoyment.
@@ -176,6 +178,7 @@ public class HTTPTask : NSObject, NSURLSessionDelegate, NSURLSessionTaskDelegate
         }
         let opt = HTTPOperation()
         let config = NSURLSessionConfiguration.defaultSessionConfiguration()
+        config.HTTPAdditionalHeaders = self.headers
         let session = NSURLSession(configuration: config, delegate: self, delegateQueue: nil)
         let task = session.dataTaskWithRequest(serialReq.request,
             completionHandler: {(data: NSData!, response: NSURLResponse!, error: NSError!) -> Void in

--- a/README.md
+++ b/README.md
@@ -278,6 +278,17 @@ request.GET("http://vluxe.io", parameters: nil, success: {(response: HTTPRespons
     })
 ```
 
+### Custom Headers
+
+Internally, SwiftHTTP uses [NSURLSessionConfiguration](https://developer.apple.com/library/ios/documentation/Foundation/Reference/NSURLSessionConfiguration_class/index.html) to configure the [NSURLSession](https://developer.apple.com/library/ios/documentation/Foundation/Reference/NSURLSession_class/index.html).
+
+HTTPTask has `public var headers = [String:AnyObject]()` which you can assign to the task object and will be set on the session.
+
+```swift
+var request = HTTPTask()
+request.headers = ["x-custom-header": "foo"]
+```
+
 ## Client/Server Example
 
 This is a full example swiftHTTP in action. First here is a quick web server in Go.


### PR DESCRIPTION
I don't know if you wanted to insulate the Session configuration from a user, but I often need access to the request headers. Since it's so easy to just add a param and use HTTPAdditionalHeaders on NSURLSessionConfiguration, I figured this would be an easy add without much added weight.

What do you think? Worth it?