### PR TITLE
Allow SwiftHTTP to be used within an app extension

### DIFF
--- a/SwiftHTTP.xcodeproj/project.pbxproj
+++ b/SwiftHTTP.xcodeproj/project.pbxproj
@@ -439,6 +439,7 @@
 		6BFD902A19C8D8B500DD99B6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -457,6 +458,7 @@
 		6BFD902B19C8D8B500DD99B6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -504,6 +506,7 @@
 		D958026C19E6EEEB003C8218 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -527,6 +530,7 @@
 		D958026D19E6EEEB003C8218 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
Currently if one links to the SwiftHTTP framework from an app extension, the compiler gives warning: _linking against dylib not safe for use in application extensions_.

The [App Extension Programming Guide > Using an Embedded Framework to Share Code](https://developer.apple.com/library/prerelease/ios/documentation/General/Conceptual/ExtensibilityPG/ExtensionScenarios.html#//apple_ref/doc/uid/TP40014214-CH21-SW5) doc mentions that the framework can be built with the `APPLICATION_EXTENSION_API_ONLY ` project setting enabled to avoid this (though it is unclear if the current config would result in App Store rejection). The 2 framework and paired test targets (once one creates an OS X test scheme) build successfully when the project setting is enabled, so it would appear as though the framework does not use any verboten API.