### PR TITLE
allow PATCH with multipart/form-data content

### DIFF
--- a/HTTPRequestSerializer.swift
+++ b/HTTPRequestSerializer.swift
@@ -88,7 +88,7 @@ public class HTTPRequestSerializer: NSObject {
             isMulti = isMultiForm(params)
         }
         if isMulti {
-            if(method != .POST && method != .PUT) {
+            if(method != .POST && method != .PUT && method != .PATCH) {
                 request.HTTPMethod = HTTPMethod.POST.rawValue // you probably wanted a post
             }
             var boundary = "Boundary+\(arc4random())\(arc4random())"


### PR DESCRIPTION
[RFC 5789](http://tools.ietf.org/html/rfc5789) does not make any recommendation or place any restrictions on the body content type when using the `PATCH` method, so allow multipart/form-data just like `POST` and `PUT`.