### PR TITLE
NSOperation dependencies

### DIFF
--- a/HTTPTask.swift
+++ b/HTTPTask.swift
@@ -202,7 +202,6 @@ public class HTTPTask : NSObject, NSURLSessionDelegate, NSURLSessionTaskDelegate
         let session = NSURLSession(configuration: config, delegate: self, delegateQueue: nil)
         let task = session.dataTaskWithRequest(serialReq.request,
             completionHandler: {(data: NSData!, response: NSURLResponse!, error: NSError!) -> Void in
-                opt.finish()
                 var extraResponse = HTTPResponse()
                 if let hresponse = response as? NSHTTPURLResponse {
                     extraResponse.headers = hresponse.allHeaderFields as? Dictionary<String,String>
@@ -215,6 +214,7 @@ public class HTTPTask : NSObject, NSURLSessionDelegate, NSURLSessionTaskDelegate
                     if failure != nil {
                         failure(error, extraResponse)
                     }
+                    opt.finish()
                     return
                 }
                 if data != nil {
@@ -225,6 +225,7 @@ public class HTTPTask : NSObject, NSURLSessionDelegate, NSURLSessionTaskDelegate
                             if failure != nil {
                                 failure(resObj.error!, extraResponse)
                             }
+                            opt.finish()
                             return
                         }
                         if resObj.object != nil {
@@ -242,6 +243,7 @@ public class HTTPTask : NSObject, NSURLSessionDelegate, NSURLSessionTaskDelegate
                 } else if failure != nil {
                     failure(error, extraResponse)
                 }
+                opt.finish()
             })
         opt.task = task
         return opt

--- a/HTTPTask.swift
+++ b/HTTPTask.swift
@@ -96,22 +96,16 @@ class BackgroundBlocks {
 /// Subclass of NSOperation for handling and scheduling HTTPTask on a NSOperationQueue.
 public class HTTPOperation : NSOperation {
     private var task: NSURLSessionDataTask!
-    private var stopped = false
     private var running = false
     
     /// Controls if the task is finished or not.
-    public var done = false
+    private var done = false
     
     //MARK: Subclassed NSOperation Methods
     
-    /// Returns if the task is asynchronous or not. This should always be false.
+    /// Returns if the task is asynchronous or not. NSURLSessionTask requests are asynchronous.
     override public var asynchronous: Bool {
-        return false
-    }
-    
-    /// Returns if the task has been cancelled or not.
-    override public var cancelled: Bool {
-        return stopped
+        return true
     }
     
     /// Returns if the task is current running.
@@ -124,26 +118,30 @@ public class HTTPOperation : NSOperation {
         return done
     }
     
-    /// Returns if the task is ready to be run or not.
-    override public var ready: Bool {
-        return !running
-    }
-    
     /// Starts the task.
     override public func start() {
-        super.start()
-        stopped = false
+        if cancelled {
+            self.willChangeValueForKey("isFinished")
+            done = true
+            self.didChangeValueForKey("isFinished")
+            return
+        }
+
+        self.willChangeValueForKey("isExecuting")
+        self.willChangeValueForKey("isFinished")
+
         running = true
         done = false
+        
+        self.didChangeValueForKey("isExecuting")
+        self.didChangeValueForKey("isFinished")
+
         task.resume()
     }
     
     /// Cancels the running task.
     override public func cancel() {
         super.cancel()
-        running = false
-        stopped = true
-        done = true
         task.cancel()
     }
     

--- a/SwiftHTTP.xcodeproj/project.pbxproj
+++ b/SwiftHTTP.xcodeproj/project.pbxproj
@@ -23,6 +23,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		832C8E641B01064F0052A5D7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6BFD900D19C8D8B500DD99B6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6BFD901519C8D8B500DD99B6;
+			remoteInfo = SwiftHTTP;
+		};
 		D958026519E6EEEB003C8218 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 6BFD900D19C8D8B500DD99B6 /* Project object */;
@@ -181,6 +188,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				832C8E651B01064F0052A5D7 /* PBXTargetDependency */,
 			);
 			name = SwiftHTTPTests;
 			productName = SwiftHTTPTests;
@@ -339,6 +347,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		832C8E651B01064F0052A5D7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6BFD901519C8D8B500DD99B6 /* SwiftHTTP */;
+			targetProxy = 832C8E641B01064F0052A5D7 /* PBXContainerItemProxy */;
+		};
 		D958026619E6EEEB003C8218 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = D958025819E6EEEB003C8218 /* SwiftHTTPOSX */;

--- a/Tests/SwiftHTTPTests.swift
+++ b/Tests/SwiftHTTPTests.swift
@@ -59,5 +59,46 @@ class SwiftHTTPTests: XCTestCase {
             XCTAssert(false, "Failure")
             expectation.fulfill()
         })
+        
+        waitForExpectationsWithTimeout(30, handler: nil)
+    }
+    
+    func testOperationDependencies() {
+        let expectation1 = expectationWithDescription("testOperationDependencies1")
+        let expectation2 = expectationWithDescription("testOperationDependencies2")
+        
+        let operationQueue = NSOperationQueue()
+        operationQueue.maxConcurrentOperationCount = 2
+        
+        var operation1Finished = false
+        
+        let urlString1 = "http://photojournal.jpl.nasa.gov/tiff/PIA19330.tif" // (4.32 MB)
+        let urlString2 = "http://photojournal.jpl.nasa.gov/jpeg/PIA19330.jpg" // (0.14 MB)
+        
+        let request1 = HTTPTask()
+        let op1 = request1.create(urlString1, method: .GET, parameters: nil, success: { (response) -> Void in
+            operation1Finished = true
+            expectation1.fulfill()
+        }) { (error, response) -> Void in
+            operation1Finished = true
+            XCTFail("request1 failed: \(error.localizedDescription)")
+            expectation1.fulfill()
+        }
+        
+        let request2 = HTTPTask()
+        let op2 = request2.create(urlString2, method: .GET, parameters: nil, success: { (response) -> Void in
+            XCTAssert(operation1Finished, "Operation 1 did not finish first")
+            expectation2.fulfill()
+        }) { (error, response) -> Void in
+            XCTFail("request1 failed: \(error.localizedDescription)")
+            XCTAssert(operation1Finished, "Operation 1 did not finish first")
+            expectation2.fulfill()
+        }
+        
+        op2?.addDependency(op1!)
+        operationQueue.addOperation(op1!)
+        operationQueue.addOperation(op2!)
+        
+        waitForExpectationsWithTimeout(30, handler: nil)
     }
 }

--- a/Tests/SwiftHTTPTests.swift
+++ b/Tests/SwiftHTTPTests.swift
@@ -22,19 +22,26 @@ class SwiftHTTPTests: XCTestCase {
     }
     
     func testGetRequest() {
-        var request = HTTPTask()
+        let expectation = expectationWithDescription("testGetRequest")
+        
+        let request = HTTPTask()
         request.GET("http://vluxe.io", parameters: nil, success: {(response: HTTPResponse) -> Void in
             if response.responseObject != nil {
                 XCTAssert(true, "Pass")
             }
-            },failure: {(error: NSError, _) -> Void in
-                XCTAssert(false, "Failure")
+            expectation.fulfill()
+        },failure: {(error: NSError, _) -> Void in
+            XCTAssert(false, "Failure")
+            expectation.fulfill()
         })
+        
+        waitForExpectationsWithTimeout(30, handler: nil)
     }
     
     func testAuthRequest() {
-        
-        var request = HTTPTask()
+        let expectation = expectationWithDescription("testAuthRequest")
+
+        let request = HTTPTask()
         var attempted = false
         request.auth = {(challenge: NSURLAuthenticationChallenge) in
             if !attempted {
@@ -47,8 +54,10 @@ class SwiftHTTPTests: XCTestCase {
             if response.responseObject != nil {
                 XCTAssert(true, "Pass")
             }
-            },failure: {(error: NSError, _) -> Void in
-                XCTAssert(false, "Failure")
+            expectation.fulfill()
+        },failure: {(error: NSError, _) -> Void in
+            XCTAssert(false, "Failure")
+            expectation.fulfill()
         })
     }
 }


### PR DESCRIPTION
While [helping someone on Stack Overflow](http://stackoverflow.com/questions/30156732/waiting-to-return-main-block-until-its-encapsulated-children-are-finished/30157270#30157270), I was looking at your `NSOperation` implementation and noticed that this would not handle dependencies and the like correctly. The fundamental issue is that (a) it wasn't implemented as asynchronous operation; and (b) the `ready` implementation would prevent dependencies from being honored even if it was properly implemented as asynchronous operation.

To illustrate the problem, I added a test case that manifests the problem. I then committed fixes to remedy the `NSOperation` issues.

Feel free to use or disregard as you see fit.

