### PR TITLE
Make stringFromParameters function public to allow override

### DIFF
--- a/HTTPRequestSerializer.swift
+++ b/HTTPRequestSerializer.swift
@@ -146,7 +146,7 @@ public class HTTPRequestSerializer: NSObject {
     }
     
     ///convert the parameter dict to its HTTP string representation
-    func stringFromParameters(parameters: Dictionary<String,AnyObject>) -> String {
+    public func stringFromParameters(parameters: Dictionary<String,AnyObject>) -> String {
         return join("&", map(serializeObject(parameters, key: nil), {(pair) in
             return pair.stringValue()
             }))


### PR DESCRIPTION
This function could be public to allow override. If for some reason you have to encode your parameters before doing the query, it allows to use these encoded parameters in the query without encoding them again in SwiftHTTP.

My use case :
To sign my query, i need to use the url parameters (encoded) and i need to guarantee that the parameters order for signing is the same in the query (which is not guaranteed currently in the stringFromParameters function)