### PR TITLE
Create enum for HTTP Status Code & added a variety response error message

### DIFF
--- a/HTTPStatusCode.swift
+++ b/HTTPStatusCode.swift
@@ -1,5 +1,5 @@
 //
-//  HTTPStatusErrorCode.swift
+//  HTTPStatusCode.swift
 //  SwiftHTTP
 //
 //  Created by Yu Kadowaki on 7/12/15.
@@ -8,8 +8,8 @@
 
 import Foundation
 
-/// HTTP Response Status Code (RFC 2616)
-public enum HTTPResponseStatusCode: Int {
+/// HTTP Status Code (RFC 2616)
+public enum HTTPStatusCode: Int {
     case Continue = 100,
         SwitchingProtocols = 101
     
@@ -61,7 +61,7 @@ public enum HTTPResponseStatusCode: Int {
     case UnknownStatus = 0
     
     init(statusCode: Int) {
-        self = HTTPResponseStatusCode(rawValue: statusCode) ?? .UnknownStatus
+        self = HTTPStatusCode(rawValue: statusCode) ?? .UnknownStatus
     }
     
     public var statusDescription: String {

--- a/HTTPStatusErrorCode.swift
+++ b/HTTPStatusErrorCode.swift
@@ -1,0 +1,159 @@
+//
+//  HTTPStatusErrorCode.swift
+//  SwiftHTTP
+//
+//  Created by Yu Kadowaki on 7/12/15.
+//  Copyright (c) 2015 Vluxe. All rights reserved.
+//
+
+import Foundation
+
+/// HTTP Response Status Code (RFC 2616)
+public enum HTTPResponseStatusCode: Int {
+    case Continue = 100,
+        SwitchingProtocols = 101
+    
+    case OK = 200,
+        Created = 201,
+        Accepted = 202,
+        NonAuthoritativeInformation = 203,
+        NoContent = 204,
+        ResetContent = 205,
+        PartialContent = 206
+    
+    case MultipleChoices = 300,
+        MovedPermanently = 301,
+        Found = 302,
+        SeeOther = 303,
+        NotModified = 304,
+        UseProxy = 305,
+        Unused = 306,
+        TemporaryRedirect = 307
+    
+    case BadRequest = 400,
+        Unauthorized = 401,
+        PaymentRequired = 402,
+        Forbidden = 403,
+        NotFound = 404,
+        MethodNotAllowed = 405,
+        NotAcceptable = 406,
+        ProxyAuthenticationRequired = 407,
+        RequestTimeout = 408,
+        Conflict = 409,
+        Gone = 410,
+        LengthRequired = 411,
+        PreconditionFailed = 412,
+        RequestEntityTooLarge = 413,
+        RequestUriTooLong = 414,
+        UnsupportedMediaType = 415,
+        RequestedRangeNotSatisfiable = 416,
+        ExpectationFailed = 417
+    
+    case InternalServerError = 500,
+        NotImplemented = 501,
+        BadGateway = 502,
+        ServiceUnavailable = 503,
+        GatewayTimeout = 504,
+        HttpVersionNotSupported = 505
+    
+    case InvalidUrl = -1001
+    
+    case UnknownStatus = 0
+    
+    init(statusCode: Int) {
+        self = HTTPResponseStatusCode(rawValue: statusCode) ?? .UnknownStatus
+    }
+    
+    public var statusDescription: String {
+        get {
+            switch self {
+            case .Continue:
+                return "Continue"
+            case .SwitchingProtocols:
+                return "Switching protocols"
+            case .OK:
+                return "OK"
+            case .Created:
+                return "Created"
+            case .Accepted:
+                return "Accepted"
+            case .NonAuthoritativeInformation:
+                return "Non authoritative information"
+            case .NoContent:
+                return "No content"
+            case .ResetContent:
+                return "Reset content"
+            case .PartialContent:
+                return "Partial Content"
+            case .MultipleChoices:
+                return "Multiple choices"
+            case .MovedPermanently:
+                return "Moved Permanently"
+            case .Found:
+                return "Found"
+            case .SeeOther:
+                return "See other Uri"
+            case .NotModified:
+                return "Not modified"
+            case .UseProxy:
+                return "Use proxy"
+            case .Unused:
+                return "Unused"
+            case .TemporaryRedirect:
+                return "Temporary redirect"
+            case .BadRequest:
+                return "Bad request"
+            case .Unauthorized:
+                return "Access denied"
+            case .PaymentRequired:
+                return "Payment required"
+            case .Forbidden:
+                return "Forbidden"
+            case .NotFound:
+                return "Page not found"
+            case .MethodNotAllowed:
+                return "Method not allowed"
+            case .NotAcceptable:
+                return "Not acceptable"
+            case .ProxyAuthenticationRequired:
+                return "Proxy authentication required"
+            case .RequestTimeout:
+                return "Request timeout"
+            case .Conflict:
+                return "Conflict request"
+            case .Gone:
+                return "Page is gone"
+            case .LengthRequired:
+                return "Lack content length"
+            case .PreconditionFailed:
+                return "Precondition failed"
+            case .RequestEntityTooLarge:
+                return "Request entity is too large"
+            case .RequestUriTooLong:
+                return "Request uri is too long"
+            case .UnsupportedMediaType:
+                return "Unsupported media type"
+            case .RequestedRangeNotSatisfiable:
+                return "Request range is not satisfiable"
+            case .ExpectationFailed:
+                return "Expected request is failed"
+            case .InternalServerError:
+                return "Internal server error"
+            case .NotImplemented:
+                return "Server does not implement a feature for request"
+            case .BadGateway:
+                return "Bad gateway"
+            case .ServiceUnavailable:
+                return "Service unavailable"
+            case .GatewayTimeout:
+                return "Gateway timeout"
+            case .HttpVersionNotSupported:
+                return "Http version not supported"
+            case .InvalidUrl:
+                return "Invalid url"
+            default:
+                return "Unknown status code"
+            }
+        }
+    }
+}

--- a/HTTPTask.swift
+++ b/HTTPTask.swift
@@ -418,14 +418,8 @@ public class HTTPTask : NSObject, NSURLSessionDelegate, NSURLSessionTaskDelegate
         :returns: An NSError.
     */
     private func createError(code: Int) -> NSError {
-        var text = "An error occured"
-        if code == 404 {
-            text = "Page not found"
-        } else if code == 401 {
-            text = "Access denied"
-        } else if code == -1001 {
-            text = "Invalid URL"
-        }
+        var text: String = HTTPResponseStatusCode(statusCode: code).statusDescription
+        
         return NSError(domain: "HTTPTask", code: code, userInfo: [NSLocalizedDescriptionKey: text])
     }
     

--- a/HTTPTask.swift
+++ b/HTTPTask.swift
@@ -418,7 +418,7 @@ public class HTTPTask : NSObject, NSURLSessionDelegate, NSURLSessionTaskDelegate
         :returns: An NSError.
     */
     private func createError(code: Int) -> NSError {
-        var text: String = HTTPResponseStatusCode(statusCode: code).statusDescription
+        var text: String = HTTPStatusCode(statusCode: code).statusDescription
         
         return NSError(domain: "HTTPTask", code: code, userInfo: [NSLocalizedDescriptionKey: text])
     }

--- a/SwiftHTTP.xcodeproj/project.pbxproj
+++ b/SwiftHTTP.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		6BFD904319C928D900DD99B6 /* HTTPRequestSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFD902F19C8D95C00DD99B6 /* HTTPRequestSerializer.swift */; };
 		6BFD904419C928D900DD99B6 /* HTTPResponseSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFD903019C8D95C00DD99B6 /* HTTPResponseSerializer.swift */; };
 		6BFD904519C928D900DD99B6 /* HTTPTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFD903119C8D95C00DD99B6 /* HTTPTask.swift */; };
+		BFE224D01B51FA8200013E3D /* HTTPStatusErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE224CF1B51FA8200013E3D /* HTTPStatusErrorCode.swift */; };
 		D958026419E6EEEB003C8218 /* SwiftHTTP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D958025919E6EEEB003C8218 /* SwiftHTTP.framework */; };
 		D958027219E6EF2B003C8218 /* SwiftHTTPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFD903D19C8D98000DD99B6 /* SwiftHTTPTests.swift */; };
 		D958027319E6EF4B003C8218 /* HTTPRequestSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFD902F19C8D95C00DD99B6 /* HTTPRequestSerializer.swift */; };
@@ -53,6 +54,7 @@
 		6BFD903919C8D96500DD99B6 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = SOURCE_ROOT; };
 		6BFD903C19C8D98000DD99B6 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Tests/Info.plist; sourceTree = "<group>"; };
 		6BFD903D19C8D98000DD99B6 /* SwiftHTTPTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftHTTPTests.swift; path = Tests/SwiftHTTPTests.swift; sourceTree = "<group>"; };
+		BFE224CF1B51FA8200013E3D /* HTTPStatusErrorCode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPStatusErrorCode.swift; sourceTree = SOURCE_ROOT; };
 		D958025919E6EEEB003C8218 /* SwiftHTTP.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftHTTP.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D958026319E6EEEB003C8218 /* SwiftHTTPOSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftHTTPOSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -118,6 +120,7 @@
 				6BFD903119C8D95C00DD99B6 /* HTTPTask.swift */,
 				6BFD903219C8D95C00DD99B6 /* HTTPUpload.swift */,
 				5CB3204D1B03F5C50050968C /* HTTPSecurity.swift */,
+				BFE224CF1B51FA8200013E3D /* HTTPStatusErrorCode.swift */,
 				6BFD903319C8D95C00DD99B6 /* SwiftHTTP.h */,
 				6BFD901919C8D8B500DD99B6 /* Supporting Files */,
 			);
@@ -317,6 +320,7 @@
 				6BFD904319C928D900DD99B6 /* HTTPRequestSerializer.swift in Sources */,
 				6BFD904419C928D900DD99B6 /* HTTPResponseSerializer.swift in Sources */,
 				5CB3204E1B03F5C50050968C /* HTTPSecurity.swift in Sources */,
+				BFE224D01B51FA8200013E3D /* HTTPStatusErrorCode.swift in Sources */,
 				6BFD904519C928D900DD99B6 /* HTTPTask.swift in Sources */,
 				6BFD903719C8D95C00DD99B6 /* HTTPUpload.swift in Sources */,
 			);

--- a/SwiftHTTP.xcodeproj/project.pbxproj
+++ b/SwiftHTTP.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 		6BFD904319C928D900DD99B6 /* HTTPRequestSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFD902F19C8D95C00DD99B6 /* HTTPRequestSerializer.swift */; };
 		6BFD904419C928D900DD99B6 /* HTTPResponseSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFD903019C8D95C00DD99B6 /* HTTPResponseSerializer.swift */; };
 		6BFD904519C928D900DD99B6 /* HTTPTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFD903119C8D95C00DD99B6 /* HTTPTask.swift */; };
-		BFE224D01B51FA8200013E3D /* HTTPStatusErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE224CF1B51FA8200013E3D /* HTTPStatusErrorCode.swift */; };
+		BFE224D01B51FA8200013E3D /* HTTPStatusCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE224CF1B51FA8200013E3D /* HTTPStatusCode.swift */; };
 		D958026419E6EEEB003C8218 /* SwiftHTTP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D958025919E6EEEB003C8218 /* SwiftHTTP.framework */; };
 		D958027219E6EF2B003C8218 /* SwiftHTTPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFD903D19C8D98000DD99B6 /* SwiftHTTPTests.swift */; };
 		D958027319E6EF4B003C8218 /* HTTPRequestSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFD902F19C8D95C00DD99B6 /* HTTPRequestSerializer.swift */; };
@@ -54,7 +54,7 @@
 		6BFD903919C8D96500DD99B6 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = SOURCE_ROOT; };
 		6BFD903C19C8D98000DD99B6 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Tests/Info.plist; sourceTree = "<group>"; };
 		6BFD903D19C8D98000DD99B6 /* SwiftHTTPTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftHTTPTests.swift; path = Tests/SwiftHTTPTests.swift; sourceTree = "<group>"; };
-		BFE224CF1B51FA8200013E3D /* HTTPStatusErrorCode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPStatusErrorCode.swift; sourceTree = SOURCE_ROOT; };
+		BFE224CF1B51FA8200013E3D /* HTTPStatusCode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPStatusCode.swift; sourceTree = SOURCE_ROOT; };
 		D958025919E6EEEB003C8218 /* SwiftHTTP.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftHTTP.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D958026319E6EEEB003C8218 /* SwiftHTTPOSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftHTTPOSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -120,7 +120,7 @@
 				6BFD903119C8D95C00DD99B6 /* HTTPTask.swift */,
 				6BFD903219C8D95C00DD99B6 /* HTTPUpload.swift */,
 				5CB3204D1B03F5C50050968C /* HTTPSecurity.swift */,
-				BFE224CF1B51FA8200013E3D /* HTTPStatusErrorCode.swift */,
+				BFE224CF1B51FA8200013E3D /* HTTPStatusCode.swift */,
 				6BFD903319C8D95C00DD99B6 /* SwiftHTTP.h */,
 				6BFD901919C8D8B500DD99B6 /* Supporting Files */,
 			);
@@ -320,7 +320,7 @@
 				6BFD904319C928D900DD99B6 /* HTTPRequestSerializer.swift in Sources */,
 				6BFD904419C928D900DD99B6 /* HTTPResponseSerializer.swift in Sources */,
 				5CB3204E1B03F5C50050968C /* HTTPSecurity.swift in Sources */,
-				BFE224D01B51FA8200013E3D /* HTTPStatusErrorCode.swift in Sources */,
+				BFE224D01B51FA8200013E3D /* HTTPStatusCode.swift in Sources */,
 				6BFD904519C928D900DD99B6 /* HTTPTask.swift in Sources */,
 				6BFD903719C8D95C00DD99B6 /* HTTPUpload.swift in Sources */,
 			);


### PR DESCRIPTION
I'd like to handle errors other than 401 and 404, so I've implemented all the HTTP status code and messages in HTTPStatusCode. Can you review it, please?