### PR TITLE
Fix charset "optional" appearing in header breaking Tomcat & others

### DIFF
--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -331,7 +331,7 @@ extension NSMutableURLRequest {
                 throw error
             }
             let charset = CFStringConvertEncodingToIANACharSetName(CFStringConvertNSStringEncodingToEncoding(String.Encoding.utf8.rawValue))
-            setValue("application/json; charset=\(charset)", forHTTPHeaderField: contentTypeKey)
+            setValue("application/json; charset=\(charset!)", forHTTPHeaderField: contentTypeKey)
         }
     }
     


### PR DESCRIPTION
Content-Type appears as "application/json; charset=Optional(utf-8)" - breaks tomcat project at the very least.