### PR TITLE
Fixing <null> value represented in JSON

### DIFF
--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -70,27 +70,26 @@ public struct HTTPPair {
     /**
     Computed property of the string representation of the storedVal
     */
-    var value: String {
+    var value: String? {
         if let v = storeVal as? String {
             return v
-        } else if let v = storeVal.description {
-            return v
+        } else if storeVal is NSNull {
+            return "NULL"
         }
-        return ""
+        
+        return storeVal.description
     }
     /**
     Computed property of the string representation of the storedVal escaped for URLs
     */
     var escapedValue: String {
-        if let v = value.escaped {
-            if let k = key {
-                if let escapedKey = k.escaped {
-                    return "\(escapedKey)=\(v)"
-                }
-            }
-            return v
+        let v = value?.escaped ?? ""
+        
+        if let escapedKey = key?.escaped {
+            return "\(escapedKey)=\(v)"
         }
-        return ""
+        
+        return v
     }
 }
 


### PR DESCRIPTION
This pull request fixes 2 issues:
1) NSNull.description produces '<null>' in JSON, which results in a invalid JSON
2) Request.swift LINE-85: if String.escaped returns a nil value, our request will not have a request parameter at all