### PR TITLE
Bug fix when nested array in GET query parameters

### DIFF
--- a/Source/Request.swift
+++ b/Source/Request.swift
@@ -135,8 +135,8 @@ extension Array: HTTPParameterProtocol {
     
     public func createPairs(_ key: String?) -> [HTTPPair] {
         var collect = [HTTPPair]()
-        for v in self {
-            let useKey = key != nil ? "\(key!)[]" : key
+        for (i, v) in self.enumerated() {
+            let useKey = key != nil ? "\(key!)[\(i)]" : key
             if let subParam = v as? HTTPParameterProtocol {
                 collect.append(contentsOf: subParam.createPairs(useKey))
             } else {


### PR DESCRIPTION
Its better to have array indexes in query parameter names, such as:
`swifthttp.com?array[0]=value1&array[1]=value2`

It fixes an issue when a GET request contains nested arrays, like the one below:

```Swift
let dict: [String : Any] = [
    "boundingbox": [["coord1", "coord2"]]
]
```
Currently `Array.createPairs` produces names without indexes:
`swifthttp.com?boundingbox[][]=coord1&boundingbox[][]=coord2`
Which causes `boundingbox` query parameter 2 root elements, as seen below

```
Array (
    [0] => Array (     // 1st Element
        [0] => coord1
    )
    [1] => Array (     // 2nd Element
        [0] => coord2
    )
)
```

With this change we will have following URL:
`swifthttp.com?boundingbox[0][0]=coord1&boundingbox[0][1]=coord2`

Now server reads the array properly as 1 root element, as seen below
```
Array (
    [0] => Array (
        [0] => coord1
        [1] => coord2
    )
)
```