### PR TITLE
Make SwiftHTTP be consumable as a Swift package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ Temporary Items
 ### Swift ###
 # Xcode
 #
+.build
 build/
 *.pbxuser
 !default.pbxuser

--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,6 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
 //
 //  Package.Swift
 //  SwiftHTTP
@@ -21,5 +24,22 @@
 import PackageDescription
 
 let package = Package(
-    name: "SwiftHTTP"
+    name: "SwiftHTTP",
+    products: [
+        .library(
+            name: "SwiftHTTP",
+            targets: ["SwiftHTTP"]),
+    ],
+    targets: [
+        .target(
+            name: "SwiftHTTP",
+            dependencies: [],
+            path: "Source",
+            exclude: ["Info.plist"]),
+        .testTarget(
+            name: "SwiftHTTPTests",
+            dependencies: ["SwiftHTTP"],
+            path: "Tests",
+            exclude: ["Info.plist"]),
+    ]
 )


### PR DESCRIPTION
This fleshes out the package file with things needed to be able
to run `swift build` and `swift test`. Tests were made compilable
or removed where the tested functionality didn't exist anymore.

Fixes #306 